### PR TITLE
Debian Install improvements  #46

### DIFF
--- a/builder/build_linux.sh
+++ b/builder/build_linux.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-VERSION=0.5
+VERSION=0.6
 NAME='zk-firma-digital'
 PACKAGE='zk-firma-digital'
 ARCH='amd64'

--- a/builder/entrypoint_debian.sh
+++ b/builder/entrypoint_debian.sh
@@ -30,7 +30,7 @@ Version: ${VERSION}
 Architecture: ${ARCH}
 Priority: optional
 Section: non-free
-Depends: pcscd, libxcb-xinerama0,  libxcb-util1 | libxcb-util0
+Depends: pcscd, libxcb-xinerama0,  libxcb-util1 | libxcb-util0, libccid, libpcre3, npm, nodejs
 Homepage: https://github.com/kuronosec/zk-firma-digital
 Maintainer: Andrés Gómez Ramírez <andresgomezram7@gmail.com>
 Description: Cliente para obtener credenciales de Zero-Knowledge basados

--- a/builder/setup.sh
+++ b/builder/setup.sh
@@ -62,7 +62,7 @@ install_system_libs() {
             ;;
     esac
 }
-
+# Install npm dependencies
 check_and_install_npm_libs(){
     echo "Checking required node libs"
     local installed_libs=()
@@ -119,7 +119,7 @@ check_zk_package(){
 create_temp_dir() {
     if [[ ! -d $TMP_DIR ]]; then 
         echo "Creating $TMP_DIR"
-        mkdir /tmp/zk-firma-digital/
+        mkdir $TMP_DIR
     fi
 }
 

--- a/builder/setup.sh
+++ b/builder/setup.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+set -e  # Exit on any error
+set -u  # Treat unset variables as an error
+
+# Required but now installed using the dockerFile pcsdc, libxcd-xinerama0, libpcre3
+#Node, Circom (And cargo & Rust) & SnarkJS
+
+REQUIRED_SYS_LIBS=("pcscd" "libxcb-xinerama0" "libpcre3" "curl") # nodejs npm
+REQUIRED_DEPENDENCIES=("")
+
+# Detect the package manager
+detect_package_manager() {
+    if command -v apt-get > /dev/null; then
+        echo "apt-get"
+    else
+        echo "Unsupported package manager" >&2
+        exit 1
+    fi
+}
+check_and_install_libs(){
+    echo "Checking required system libs"
+    local installed_libs=()
+    local missing_libs=()
+    for dep in "${REQUIRED_SYS_LIBS[@]}"; do
+        if dpkg -l | grep -q "$dep"; then 
+            installed_libs+=("$dep")
+        else
+            missing_libs+=("$dep")
+        fi
+    done
+    echo "Required libs that are already satisfied: ${installed_libs[*]}"
+    echo "Required & missing libs: ${missing_libs[*]}"
+    for dep in "${missing_libs[@]}"; do
+        install_system_libs $(detect_package_manager) $dep
+    done
+}
+# Install dependencies based on the package manager
+install_system_libs() {
+    local pkg_manager="$1"
+    local library="$2"
+    case "$pkg_manager" in
+        apt-get)
+            echo "Installing: $2"
+            sudo apt-get install -y $2
+            ;;
+        *)
+            echo "Unsupported package manager: $pkg_manager" >&2
+            exit 1
+            ;;
+    esac
+}
+
+
+
+
+
+# check_dependencies(){
+#     echo "Checking host dependencies"
+#     local missing_deps()
+#     for dep in "${REQUIRED_DEPENDENCIES[@]}"; do
+#         if ! command -v "$dep" &>/dev/null; then
+#             missing_deps+=("$dep")
+#         fi
+#     done
+
+#     if [[ ${#missing_deps[@] -gt 0} ]]; then
+#         echo "Missing dependencies: ${missing_deps[*]}"
+#         # Take that list and install them.
+#         exit 1
+#     fi 
+# }
+
+#Temp dir to download the required files for installation.
+create_temp_dir() {
+    dir='/tmp/zk-firma-digital/'
+    if [[ ! -d $dir ]]; then 
+        echo "Creating $dir"
+        mkdir /tmp/zk-firma-digital/
+    fi
+}
+
+
+
+# Install the binary
+install_binary() {
+    local binary_path="$1"
+    sudo install -m 0755 "$binary_path" /usr/local/bin/\<REPLACE\>
+}
+
+# Main function
+main() {
+    echo "Detecting package manager..."
+    local pkg_manager
+    pkg_manager=$(detect_package_manager)
+    echo "Package manager detected: $pkg_manager"
+
+    echo "Installing dependencies..."
+    install_dependencies "$pkg_manager"
+
+    echo "Installing binary..."
+    install_binary "/binary path"
+
+    echo "Installation completed successfully!"
+}
+
+# main "$@"
+
+check_and_install_libs
+
+
+# Some dependencies: Node, Circom, Gaudi, 
+# Circom requires rust to be installed as well
+
+# This script will check all the dependencies are met if not installed it will proceed with the installation.
+# is going to install all the dependencies and also the ZK-firma digital binary.
+# Might check the installer.iss to see if we can embed that there
+# 
+
+

--- a/builder/setup.sh
+++ b/builder/setup.sh
@@ -129,7 +129,7 @@ install_zk_firma(){
     check_zk_package
     if [[ -f "${TMP_DIR}${ZK_PACKAGE}" ]]; then
         echo "$ZK_PACKAGE exists. Installing..." 
-        sudo dpkg -i $ZK_PACKAGE
+        sudo dpkg -i ${TMP_DIR}$ZK_PACKAGE
     else
         echo "$ZK_PACKAGE was not found. Aborting installation." 
         exit 1
@@ -143,6 +143,7 @@ main() {
     check_and_install_npm_libs
     install_zk_firma
     echo "Installation completed successfully!"
+    echo "To execute run the following command: /usr/share/zk-firma-digital/zk-firma-digital.bin"
 }
 
 main

--- a/builder/setup.sh
+++ b/builder/setup.sh
@@ -3,10 +3,12 @@
 set -e  # Exit on any error
 set -u  # Treat unset variables as an error
 
-# Required but now installed using the dockerFile pcsdc, libxcd-xinerama0, libpcre3
-#Node, Circom (And cargo & Rust) & SnarkJS
 
-REQUIRED_SYS_LIBS=("pcscd" "libxcb-xinerama0" "libpcre3" "curl") # nodejs npm
+#Node, Circom (And cargo & Rust) & SnarkJS within the host machine
+
+
+# Download dependencies to the target dir.
+REQUIRED_SYS_LIBS=("pcscd" "libccid" "libxcb-xinerama0" "libpcre3" "curl" "nodejs" "pcsc-tools" "libasedrive-usb") # nodejs npm
 REQUIRED_DEPENDENCIES=("")
 
 # Detect the package manager


### PR DESCRIPTION
# What has been done
To fix: https://github.com/kuronosec/zk-firma-digital/issues/46 
Created a setup.sh script to prepare the Debian OS with all the required packages in order to get ZK-Firma-Digital work as a charm. 

# Functionality 
The script does the following:
- Check OS and NPM dependencies
- If dependencies do not exists, the script will automatically install them (OS Libs & NPM libs)
- Download the zk-firma-digital .deb package 
- Check the SHA256 SUM of the  zk-firma-digital .deb package  
- Install the zk-firma-digital .deb package

# Prerequisites:
- Firma Digital - Gaudi must be installed manually in order to get the ZK-Firma-Digital working as expected (This will be added later on in the https://github.com/kuronosec/zk-firma-digital/issues/48)

# Improvement for the users
I suggest to enable a download link of the setup.sh so they can curl it and run ./setup.sh  to automatically install all the piecies.

# What to know?
For every new release the `RELEASE_VERSION` and `EXPECTED_SHA256` must be updated accordingly. 


# Evidence 
Attached you can find a gif showing the procedure, 

![installsetup sh-ezgif com-optimize](https://github.com/user-attachments/assets/e54ae964-3ea5-4609-b0ba-7b5dca59a389)


Please feel free to suggest any changes. 


